### PR TITLE
Stabilize gamepad input after connect

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -90,6 +90,9 @@ interface AxisCalibration {
   }
 }
 
+// Warm-up polls per gamepad before treating button/axis changes as real input
+const initFrameCount: Record<number, number> = {}
+
 // State
 const state = reactive<AppState>({
   actions: ACTIONS.map(action => ({ ...action, bindings: [] })),
@@ -490,10 +493,25 @@ function detectTestModeInput(gamepad: Gamepad, gamepadIndex: number) {
       buttons: gamepad.buttons.map(b => ({ pressed: b.pressed })),
       axes: [...gamepad.axes]
     }
+    initFrameCount[gamepadIndex] = 0
+    return
+  }
+
+  if ((initFrameCount[gamepadIndex] ?? 0) < 3) {
+    initFrameCount[gamepadIndex] = (initFrameCount[gamepadIndex] ?? 0) + 1
+    state.previousGamepadState[gamepadIndex] = {
+      buttons: gamepad.buttons.map(b => ({ pressed: b.pressed })),
+      axes: [...gamepad.axes]
+    }
     return
   }
 
   const prevState = state.previousGamepadState[gamepadIndex]
+
+  state.previousGamepadState[gamepadIndex] = {
+    buttons: gamepad.buttons.map(b => ({ pressed: b.pressed })),
+    axes: [...gamepad.axes]
+  }
 
   // Check buttons
   for (let i = 0; i < gamepad.buttons.length; i++) {
@@ -585,11 +603,6 @@ function detectTestModeInput(gamepad: Gamepad, gamepadIndex: number) {
       }
     }
   }
-
-  state.previousGamepadState[gamepadIndex] = {
-    buttons: gamepad.buttons.map(b => ({ pressed: b.pressed })),
-    axes: [...gamepad.axes]
-  }
 }
 
 function confirmInput() {
@@ -635,10 +648,25 @@ function detectInput(gamepad: Gamepad, gamepadIndex: number) {
       buttons: gamepad.buttons.map(b => ({ pressed: b.pressed })),
       axes: [...gamepad.axes]
     }
+    initFrameCount[gamepadIndex] = 0
+    return
+  }
+
+  if ((initFrameCount[gamepadIndex] ?? 0) < 3) {
+    initFrameCount[gamepadIndex] = (initFrameCount[gamepadIndex] ?? 0) + 1
+    state.previousGamepadState[gamepadIndex] = {
+      buttons: gamepad.buttons.map(b => ({ pressed: b.pressed })),
+      axes: [...gamepad.axes]
+    }
     return
   }
 
   const prevState = state.previousGamepadState[gamepadIndex]
+
+  state.previousGamepadState[gamepadIndex] = {
+    buttons: gamepad.buttons.map(b => ({ pressed: b.pressed })),
+    axes: [...gamepad.axes]
+  }
 
   // Check buttons
   for (let i = 0; i < gamepad.buttons.length; i++) {
@@ -709,11 +737,6 @@ function detectInput(gamepad: Gamepad, gamepadIndex: number) {
         return
       }
     }
-  }
-
-  state.previousGamepadState[gamepadIndex] = {
-    buttons: gamepad.buttons.map(b => ({ pressed: b.pressed })),
-    axes: [...gamepad.axes]
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a short warm-up window (first few polls per gamepad) before treating button and axis changes as real input. That avoids spurious edge detection when the Gamepad API or hardware state is still settling after connect, which is common with latching switches and rotary selectors.

Also updates the stored previous state at the start of each detection pass so one latched control does not prevent other buttons from being detected on following frames.

## Testing

- [ ] Connect HOTAS / gamepad, start configuring or test mode, confirm no false bindings on plug-in
- [ ] Normal button and axis binding still works as before